### PR TITLE
Fix a bug of PathSeparator on window:

### DIFF
--- a/logd.go
+++ b/logd.go
@@ -67,10 +67,20 @@ type LogOption struct {
 	Mails      Emailer   // 告警邮件
 }
 
+func osSep() string {
+	var sep string
+	if os.IsPathSeparator('\\') {
+		sep = "\\"
+	} else {
+		sep = "/"
+	}
+	return sep
+}
+
 // 新建日志打印器
 func New(option LogOption) *Logger {
 	wd, _ := os.Getwd()
-	index := strings.LastIndex(wd, "/")
+	index := strings.LastIndex(wd, osSep())
 	logger := &Logger{
 		obj:   wd[index+1:],
 		out:   option.Out,


### PR DESCRIPTION
index := strings.LastIndex(wd, "/")
For Windows, the PathSeparator is "\\", so we add a function osSep
to get the PathSeparator on difference OS.
and then it should be use as below:
index := strings.LastIndex(wd, osSep())